### PR TITLE
Added support for more attributes and updated dependencies

### DIFF
--- a/lib/parsers/netscape.js
+++ b/lib/parsers/netscape.js
@@ -26,14 +26,27 @@ exports.parse = function(html, callback) {
             data.type = "bookmark";
             data.url = node.childNodes[i].getAttribute("href");
             data.title = node.childNodes[i].textContent;
-            data.add_date = node.childNodes[i].getAttribute("add_date");
+
+            var add_date = node.childNodes[i].getAttribute("add_date");
+            if( add_date ) {
+              data.add_date = add_date;
+            }
           }
           else if( node.childNodes[i].tagName == "H3" ){
             // is folder
             data.type = "folder";
             data.title = node.childNodes[i].textContent;
-            data.add_date = node.childNodes[i].getAttribute("add_date");
-            data.last_modified = node.childNodes[i].getAttribute("last_modified");
+
+            var add_date = node.childNodes[i].getAttribute("add_date");
+            var last_modified = node.childNodes[i].getAttribute("last_modified");
+
+            if( add_date ) {
+              data.add_date = add_date;
+            }
+
+            if( last_modified ) {
+              data.last_modified = last_modified;
+            }
           }
           else if( node.childNodes[i].tagName == "DL" ){
             data.__dir_dl = node.childNodes[i];

--- a/lib/parsers/netscape.js
+++ b/lib/parsers/netscape.js
@@ -26,11 +26,14 @@ exports.parse = function(html, callback) {
             data.type = "bookmark";
             data.url = node.childNodes[i].getAttribute("href");
             data.title = node.childNodes[i].textContent;
+            data.add_date = node.childNodes[i].getAttribute("add_date");
           }
           else if( node.childNodes[i].tagName == "H3" ){
             // is folder
             data.type = "folder";
             data.title = node.childNodes[i].textContent;
+            data.add_date = node.childNodes[i].getAttribute("add_date");
+            data.last_modified = node.childNodes[i].getAttribute("last_modified");
           }
           else if( node.childNodes[i].tagName == "DL" ){
             data.__dir_dl = node.childNodes[i];

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "license": "ISC",
   "dependencies": {
-    "async": "^0.9.0",
-    "jsdom": "3.x.x"
+    "async": "^2.0.1",
+    "jsdom": "^9.5.0"
   },
   "devDependencies": {
     "mocha": "^2.1.0",


### PR DESCRIPTION
I was not able to  able to `npm install bookmarks-parser` on my machine with `Node v6.2.2`. I tracked down the issue to the out dated `jsdom@3.0.0` dependency which uses `contextify: '>= 0.1.9 < 0.2.0'` which wouldn't install for me. I updated the dependencies to the latest and it worked like a charm.

At the same time I added two new attributes which are in the Chrome bookmarks export which are: 

- add_date
- last_modified

I tested with my own exported bookmarks from Chrome and the tests all passed. 